### PR TITLE
Duplication of backup file

### DIFF
--- a/Windows_Path_Enumerate.ps1
+++ b/Windows_Path_Enumerate.ps1
@@ -388,9 +388,12 @@ Function Fix-ServicePath {
                                 }
                                 If ($Backup){
                                     $BcpFileName = "$BackupFolder\$soft_service`_$($OriginalPath.PSChildName)`_$(get-date -uFormat "%Y-%m-%d_%H%M%S").reg"
+									$BcpTmpFileName = "$BackupFolder\$soft_service`_$($OriginalPath.PSChildName)`_$(get-date -uFormat "%Y-%m-%d_%H%M%S").tmp"
                                     $BcpRegistryPath = $RegistryPath -replace '\:'
                                     Write-Output "$(get-date -format u)  :  Creating registry backup : $BcpFileName"
-                                    $ExportResult = REG EXPORT $BcpRegistryPath $BcpFileName | Out-String
+                                    $ExportResult = REG EXPORT $BcpRegistryPath $BcpTmpFileName | Out-String
+									more $BcpTmpFileName >> $BcpFileName
+									Remove-Item $BcpTmpFileName -Force -ErrorAction "SilentlyContinue"
                                     Write-Output "$(get-date -format u)  :  Result : $($ExportResult -split '\r\n' | Where-Object {$_ -NotMatch '^$'})"
                                 }
                                 If (! $WhatIf) {

--- a/Windows_Path_Enumerate.ps1
+++ b/Windows_Path_Enumerate.ps1
@@ -388,12 +388,12 @@ Function Fix-ServicePath {
                                 }
                                 If ($Backup){
                                     $BcpFileName = "$BackupFolder\$soft_service`_$($OriginalPath.PSChildName)`_$(get-date -uFormat "%Y-%m-%d_%H%M%S").reg"
-									$BcpTmpFileName = "$BackupFolder\$soft_service`_$($OriginalPath.PSChildName)`_$(get-date -uFormat "%Y-%m-%d_%H%M%S").tmp"
+                                    $BcpTmpFileName = "$BackupFolder\$soft_service`_$($OriginalPath.PSChildName)`_$(get-date -uFormat "%Y-%m-%d_%H%M%S").tmp"
                                     $BcpRegistryPath = $RegistryPath -replace '\:'
                                     Write-Output "$(get-date -format u)  :  Creating registry backup : $BcpFileName"
                                     $ExportResult = REG EXPORT $BcpRegistryPath $BcpTmpFileName | Out-String
-									more $BcpTmpFileName >> $BcpFileName
-									Remove-Item $BcpTmpFileName -Force -ErrorAction "SilentlyContinue"
+                                    more $BcpTmpFileName >> $BcpFileName
+                                    Remove-Item $BcpTmpFileName -Force -ErrorAction "SilentlyContinue"
                                     Write-Output "$(get-date -format u)  :  Result : $($ExportResult -split '\r\n' | Where-Object {$_ -NotMatch '^$'})"
                                 }
                                 If (! $WhatIf) {


### PR DESCRIPTION
In some cases software creates two registry entries for itself (one for each architecture). Ex., 
```
[HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\7-Zip]
[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\7-Zip]
```
For such cases backup will try to create two files with similar names. This will make the whole backup process stuck since `REG EXPORT` wait for user's decision about overwriting one file with the another. 

I haven't found option in EXPORT to append registry params in one file out of the box. So, I decided to use a temporary file to gather all possible configurations for a software in one file. Such backup files will work with restoring procedure (`regedit /s` command).