### PR TITLE
Fix Tee-Log FilePath usage

### DIFF
--- a/Windows_Path_Enumerate.ps1
+++ b/Windows_Path_Enumerate.ps1
@@ -450,9 +450,9 @@ Function Tee-Log {
         [switch]$Silent
     )
     if($Silent){
-        $Input | Out-File -FilePath $LogName -Append
+        $Input | Out-File -FilePath $FilePath -Append
     } else {
-        $Input | Tee-Object -FilePath $LogName -Append
+        $Input | Tee-Object -FilePath $FilePath -Append
     }
 }
 


### PR DESCRIPTION
## Summary
- fix Tee-Log function so it uses provided FilePath parameter

## Testing
- `pwsh -NoLogo -NoProfile -Command "& ./Test/Start-Tests.ps1"` *(fails: command not found)*
- `powershell -NoLogo -NoProfile -Command "& ./Test/Start-Tests.ps1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685317180ac4833192b2a42aa5be4a51